### PR TITLE
blog cardのcss調整

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@storybook/manager-webpack5": "^6.5.9",
     "@storybook/react": "^6.5.9",
     "@storybook/testing-library": "^0.0.13",
+    "@tailwindcss/line-clamp": "^0.4.0",
     "@types/node": "17.0.25",
     "@types/qs": "^6.9.7",
     "@types/react": "18.0.6",

--- a/src/components/top/Tab/Blog.tsx
+++ b/src/components/top/Tab/Blog.tsx
@@ -15,22 +15,22 @@ const Blog = ({ blogPosts }: Props) => {
           <Link href={"/blog/" + value.slug} key={value.id} prefetch={false}>
             <a>
               <div className="flex h-24 px-4 py-3 sm:hover:bg-light-gray">
-                <div className="h-[72px] w-32">
+                <div className="h-[72px] w-32 min-w-fit">
                   <Image
                     src={
                       value.featuredImage?.node.sourceUrl
                         ? value.featuredImage.node.sourceUrl
                         : "/img/ogp.png"
                     }
-                    width="128px"
-                    height="72px"
+                    width="128"
+                    height="72"
                     alt="profile"
                   />
                 </div>
 
-                <div className="flex-auto pl-4">
-                  <div className="h-14">{value.title}</div>
-                  <div className="text-right text-xs">
+                <div className="relative flex-auto pl-4">
+                  <div className="leading-5 line-clamp-2">{value.title}</div>
+                  <div className="absolute bottom-0 right-0 text-right text-xs">
                     {value.date.toString()}
                   </div>
                 </div>

--- a/src/components/top/Tab/Blog.tsx
+++ b/src/components/top/Tab/Blog.tsx
@@ -30,7 +30,7 @@ const Blog = ({ blogPosts }: Props) => {
 
                 <div className="relative flex-auto pl-4">
                   <div className="leading-5 line-clamp-2">{value.title}</div>
-                  <div className="absolute bottom-0 right-0 text-right text-xs">
+                  <div className="absolute bottom-0 right-0 text-xs">
                     {value.date.toString()}
                   </div>
                 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,5 +28,5 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [],
+  plugins: [require("@tailwindcss/line-clamp")],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2530,6 +2530,11 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
+"@tailwindcss/line-clamp@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.4.0.tgz#03353e31e77636b785f2336e8c978502cec1de81"
+  integrity sha512-HQZo6gfx1D0+DU3nWlNLD5iA6Ef4JAXh0LeD8lOGrJwEDBwwJNKQza6WoXhhY1uQrxOuU8ROxV7CqiQV4CoiLw==
+
 "@testing-library/dom@^8.3.0":
   version "8.14.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.14.0.tgz#c9830a21006d87b9ef6e1aae306cf49b0283e28e"


### PR DESCRIPTION
ブログカードのレイアウト統一

### 実装内容

- blogの画像にmin-w-fitを指定
- @tailwindcss/line-clampを追加
- blogのタイトルにline-clamp-2を指定
- blogの日付にabsolute bottom-0 right-0を指定
- blogの日付からtext-rightを削除