### PR TITLE
fix: correct favicon ico link

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -37,7 +37,7 @@ const jsonLd = {
     <meta content={Astro.generator} name="generator" />
 
     <link href="/favicon.svg" rel="icon" type="image/svg+xml" />
-    <link href="/favicon.svg" rel="icon" type="image/x-icon" />
+    <link href="/favicon.ico" rel="icon" type="image/x-icon" />
 
     <link href={canonicalUrl} rel="canonical" />
     <link href={`${BASE_URL}`} hreflang="en" rel="alternate" />


### PR DESCRIPTION
## 概要
- favicon の ICO 用リンクが誤って SVG を参照していたため、適切な `favicon.ico` を指すよう修正しました。

## 設定・依存差分
- なし

## UI変更
- なし（スクリーンショット不要）

## 検証結果
- ✅ `npm run lint`
- ✅ `npm run build`

## レビュアー
- @kanaru-ssk

Refs #170
