### PR TITLE
fix: join descriptions with space

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,7 +10,7 @@ type Props = {
 };
 
 const { lang, title, descriptions } = Astro.props;
-const description = descriptions.join();
+const description = descriptions.join(" ");
 const canonicalUrl = `${BASE_URL}${lang === DEFAULT_LANG ? "" : `/${lang}`}`;
 
 const jsonLd = {


### PR DESCRIPTION
## 概要
- meta/OG/Twitter description の結合方法をカンマからスペースに変更し、読みやすい一文になるようにしました。

## 設定・依存差分
- なし

## UI変更
- なし（スクリーンショット不要）

## 検証結果
- ✅ `npm run lint`
- ✅ `npm run build`

## レビュアー
- @kanaru-ssk

Refs #169
