### PR TITLE
fix: unify hreflang codes

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       lastmod: new Date(),
       i18n: {
         defaultLocale: "en",
-        locales: { en: "en-US", ja: "ja-JP" },
+        locales: { en: "en", ja: "ja" },
       },
     }),
   ],


### PR DESCRIPTION
## 変更概要
- sitemap出力で使う `hreflang` をHTML側と同じ `en` / `ja` のみになるよう `astro.config.ts` の locales を更新しました。

## 設定・依存の差分
- なし

## UI変更
- なし

## 実行結果
- [x] npm run lint
- [x] npm run build

Fixes #179
