### PR TITLE
fix: make footer year dynamic

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,6 +12,7 @@ type Props = {
 const { lang, title, descriptions } = Astro.props;
 const description = descriptions.join(" ");
 const canonicalUrl = `${BASE_URL}${lang === DEFAULT_LANG ? "" : `/${lang}`}`;
+const currentYear = new Date().getFullYear();
 
 const jsonLd = {
   "@context": "https://schema.org",
@@ -96,6 +97,6 @@ const jsonLd = {
       <slot />
     </main>
 
-    <footer>&copy; 2025 {title}</footer>
+    <footer>&copy; {currentYear} {title}</footer>
   </body>
 </html>


### PR DESCRIPTION
## 変更概要
- `BaseLayout` で現在年を `new Date().getFullYear()` から取得し、フッターのコピーライト表記を自動更新するようにしました。

## 設定・依存の差分
- なし

## UI変更
- 著作権表記が最新年になります（スクリーンショット不要と判断）。

## 実行結果
- [x] npm run lint
- [x] npm run build

Fixes #182
