### PR TITLE
chore: unify node 24 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ My personal web site
 - [Astro v5](https://astro.build/)
 - [GitHub](https://github.com/) (Actions and Pages)
 
+## Requirements
+
+- Node.js 24.x (LTS)
+
 ## Getting Started
 
 To run this project locally:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "lint": "prettier . --check && eslint",
     "format": "prettier . --write && eslint --fix"
   },
+  "engines": {
+    "node": "24.x"
+  },
   "devDependencies": {
     "@astrojs/sitemap": "^3.6.0",
     "@astrojs/ts-plugin": "^1.10.5",


### PR DESCRIPTION
## 変更概要
- `package.json` に `engines.node: 24.x` を追加し、リポジトリ全体でNode 24 LTSを前提とする設定に統一しました。
- READMEに要件として「Node.js 24.x (LTS)」を追記しました。

## 設定・依存の差分
- 依存追加なし

## 実行結果
- [x] npm run lint
- [x] npm run build

Fixes #183
